### PR TITLE
use compat for UUIDs

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -120,6 +120,8 @@ Base.copy(sp::SyncPlot) = fork(sp)  # defined by each SyncPlot{TD}
 # Display frontends #
 # ----------------- #
 
+using Compat.UUIDs
+
 @require Juno include("displays/juno.jl")
 @require WebIO include("displays/webio.jl")
 include("displays/electron.jl")

--- a/src/displays/electron.jl
+++ b/src/displays/electron.jl
@@ -3,14 +3,14 @@
 # ----------- #
 
 mutable struct ElectronDisplay <: AbstractPlotlyDisplay
-    divid::Base.Random.UUID
+    divid::UUIDs.UUID
     w
 end
 
 const ElectronPlot = SyncPlot{ElectronDisplay}
 
-ElectronDisplay() = ElectronDisplay(Base.Random.uuid4(), nothing)
-ElectronDisplay(divid::Base.Random.UUID) = ElectronDisplay(divid, nothing)
+ElectronDisplay() = ElectronDisplay(UUIDs.uuid4(), nothing)
+ElectronDisplay(divid::UUIDs.UUID) = ElectronDisplay(divid, nothing)
 ElectronDisplay(p::Plot) = ElectronDisplay(p.divid)
 ElectronPlot(p::Plot) = ElectronPlot(p, ElectronDisplay(p.divid))
 

--- a/src/displays/ijulia.jl
+++ b/src/displays/ijulia.jl
@@ -3,7 +3,7 @@
 # ---------------------- #
 
 mutable struct JupyterDisplay <: AbstractPlotlyDisplay
-    divid::Base.Random.UUID
+    divid::UUIDs.UUID
     displayed::Bool
     cond::Condition  # for getting data back from js
 end


### PR DESCRIPTION
For sglyon/PlotlyJS.jl#200... addresses issue where precompilation currently fails due to use of Base.Random.[uuid stuff]